### PR TITLE
Implementing showing all sampling spots at once, instead of one at a time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# MSVS project files
+.vs
+/bin
+/obj
+/packages
+*.sln
+*.csproj
+*.user
+*.suo
+*.config
+
+# python files
+*.pyc
+*.pyo
+
+# packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+
+# installer logs
+pip-log.txt
+
+# vi swap and temp files
+*.swp
+*.swo
+*~
+
+# compiled source
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so

--- a/js/Scene3D.js
+++ b/js/Scene3D.js
@@ -502,6 +502,22 @@ Scene3D.prototype = Object.create(EventSource.prototype, {
             offset_dimension = this._model_exploding.offset_dimension
             exploding_dimension = this._model_exploding.dimension
 
+            delta_x = model_max_x  - model_min_x;
+            delta_y = model_max_y  - model_min_y;
+            delta_z = model_max_z  - model_min_z;
+
+            var zPartitionSize = delta_z / number_of_partitions;
+            var zPartitionGap = delta_z * partition_separation_ratio / 2;
+            var yPartitionOffset = delta_y * slice_offsets / 2;
+
+            this.spots.forEach(function (spot) {
+                if (exploding_dimension == "z" && offset_dimension == "y") {
+                    var lowerPartitionCount = Math.floor((spot.z - model_min_z) / zPartitionSize);
+                    spot.z += lowerPartitionCount * zPartitionGap;
+                    spot.y += lowerPartitionCount * yPartitionOffset;
+                }
+            });
+
             //Look over three vertices at a time, and then remove all 3 if any of the exceed a certain threshold
             current_array_pointer = 0
             for( i = 0; i < colors.length/9; i++){
@@ -546,10 +562,6 @@ Scene3D.prototype = Object.create(EventSource.prototype, {
                     x_idx = base + j * 3
                     y_idx = base + j * 3 + 1
                     z_idx = base + j * 3 + 2
-
-                    delta_x = model_max_x  - model_min_x;
-                    delta_y = model_max_y  - model_min_y;
-                    delta_z = model_max_z  - model_min_z;
 
                     //Actually doing the update
                     if(exploding_dimension == "x"){

--- a/js/SpotLabel3D.js
+++ b/js/SpotLabel3D.js
@@ -7,6 +7,7 @@ function SpotLabel3D(group, scene) {
     this._view = null;
     this._raycastPromise = null;
     this._div = null;
+    this._divs = [];
     this._changed = false;
 }
 
@@ -40,26 +41,30 @@ SpotLabel3D.prototype = Object.create(SpotLabelBase.prototype, asProps({
         this._group.requestAnimationFrame();
     },
 
-    update: function() {
+    update: function () {
         if (this._changed) {
-            if (this.div) {
-                this.removeDiv();
+            if (this._divs) {
+                this._divs.forEach(function(div) {
+                    div.parentNode.removeChild(div);
+                });
+                this._divs = [];
             }
             if (this._view && this._spot) {
-                this.createDiv('SpotLabel3D');
-                this.textContent = this._spot.name;
-                this._view.div.appendChild(this.div);
+                this._scene.spots.forEach(function (spot) {
+                    this.createDiv('SpotLabel3D');
+                    this._div.textContent = spot.name;
+                    this._view.div.appendChild(this.div);
+
+                    var position = this._scene.spotToWorld(spot);
+                    if (position) {
+                        var point2D = this._view.projectPosition(position);
+                        this._div.style.left = point2D.x + 'px'
+                        this._div.style.top = point2D.y + 'px'
+                    }
+                    this._divs.push(this.div);
+                }.bind(this));
             }
             this._changed = false;
-        }
-
-        if (this._view && this._spot && this._div) {
-            var position = this._scene.spotToWorld(this._spot);
-            if (position) {
-                var point2D = this._view.projectPosition(position);
-                this._div.style.left = point2D.x + 'px'
-                this._div.style.top = point2D.y + 'px'
-            }
         }
     },
 }));

--- a/js/Workspace.js
+++ b/js/Workspace.js
@@ -191,6 +191,7 @@ Workspace.prototype = Object.create(EventSource.prototype, {
                     var blob = result.items[i].blob;
                     switch (blob.type) {
                         case 'text/csv':
+                        case 'application/vnd.ms-excel':
                             this.loadIntensities(blob);
                             break;
 

--- a/js/main.js
+++ b/js/main.js
@@ -182,21 +182,21 @@ function init() {
 }
 
 var KEYBOARD_SHORTCUTS = {
-    'U+004F': chooseFilesToOpen, // Ctrl + O
-    'U+0046': function() { // Ctrl + F
+    '79': chooseFilesToOpen, // Ctrl + O
+    '70': function() { // Ctrl + F
         g_mapSelector.activate();
     },
-    'U+0053': function() { // Ctrl + S
+    '83': function() { // Ctrl + S
         var name = g_workspace.mapName || 'image';
         g_views.export().then(function(blob) {
             saveAs(blob, name + '.png');
         });
     },
-    'Up': function() {
+    '38': function() {
         g_mapSelector.blink();
         g_mapSelector.navigate(MapSelector.Direction.UP);
     },
-    'Down': function() {
+    '40': function() {
         g_mapSelector.blink();
         g_mapSelector.navigate(MapSelector.Direction.DOWN);
     },
@@ -209,8 +209,9 @@ function onKeyDown(event) {
         if (!event.ctrlKey || event.altKey || event.metaKey) return;
     }
 
-    if (event.keyIdentifier in KEYBOARD_SHORTCUTS) {
-        var handler = KEYBOARD_SHORTCUTS[event.keyIdentifier];
+    var key = (event.which ? event.which : event.keyCode).toString();
+    if (key in KEYBOARD_SHORTCUTS) {
+        var handler = KEYBOARD_SHORTCUTS[key];
         handler();
         event.stopPropagation();
         event.preventDefault();

--- a/main.css
+++ b/main.css
@@ -137,6 +137,7 @@ dialog#errors > ul {
     background-color: rgba(255, 255, 255, 0.2);
     padding: 0 4px;
     pointer-events: none;
+    font-size: small;
 }
 
 .SpotLabel3D > a, .SpotLabel2D > a {
@@ -150,6 +151,6 @@ dialog#errors > ul {
     top: -2px;
     width: 4px;
     height: 4px;
-    background-color: white;
+    background-color: red;
     border-radius: 2px;
 }


### PR DESCRIPTION
To see it in action, one should click at any sampling spot on a model. All spot labels should appear